### PR TITLE
change validator to support Lmod **3.x**

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -237,8 +237,14 @@ phases:
 
                   echo "Checking Intel MPI 20xx installed and module available..."
                   unset MODULEPATH
-                  source /etc/profile.d/modules.sh
-                  (module avail intelmpi)2>&1 | grep "/opt/intel/mpi/20.*/modulefiles/"
+                  if [[ -f /etc/profile.d/modules.sh ]] ; then
+                    source /etc/profile.d/modules.sh
+                  elif [[ -f /etc/profile.d/00-modulepath.sh ]] ; then
+                    source /etc/profile.d/00-modulepath.sh
+                  else
+                    echo "Check failed to find module path" && exit 1
+                  fi
+                  (module avail intelmpi)2>&1 | grep "/opt/intel/mpi/20.*/modulefiles"
                   [[ $? -ne 0 ]] && echo "Check Intel MPI failed" && exit 1
                 else
                   dpkg -l | grep libfabric && modinfo efa | grep efa && [ -d /opt/amazon/efa ]
@@ -331,7 +337,13 @@ phases:
               if [ {{ validate.ArmPLSupported.outputs.stdout }} == true ]; then
                 echo "Checking gcc version and module loaded..."
                 unset MODULEPATH
-                source /etc/profile.d/modules.sh
+                if [[ -f /etc/profile.d/modules.sh ]] ; then
+                  source /etc/profile.d/modules.sh
+                elif [[ -f /etc/profile.d/00-modulepath.sh ]] ; then
+                  source /etc/profile.d/00-modulepath.sh
+                else
+                  echo "Check failed to find module path" && exit 1
+                fi
                 (module avail)2>&1 | grep armpl/{{ validate.ArmPLVersion.outputs.stdout }}
                 [[ $? -ne 0 ]] && echo "Check armpl version failed" && exit 1
                 module load armpl/{{ validate.ArmPLVersion.outputs.stdout }}


### PR DESCRIPTION
pcluster image-create fails if you swap out environment-modules for Lmod as module.sh does not exist and Lmod does not show a trailing / on the module path in its avail output

### Description of changes

changing the validator to allow for using Lmod rather than environment-modules

removed the trailing / (slash) from grep of path to intel MPI library

### Tests

    yum remove -y environment-modules openmpi40-aws
    yum install -y Lmod

then run
```
set -vx
                echo "Checking efa packages installed..."
                  rpm -qa | grep libfabric && rpm -qa | grep efa-
                  [[ $? -ne 0 ]] && echo "Check efa rpm failed" && exit 1

                  echo "Checking Intel MPI 20xx installed and module available..."
                  unset MODULEPATH
                  if [[ -f /etc/profile.d/modules.sh ]] ; then
                    source /etc/profile.d/modules.sh
                  elif [[ -f /etc/profile.d/00-modulepath.sh ]] ; then
                    source /etc/profile.d/00-modulepath.sh
                  else
                    echo "Check failed to find module path" && exit 1
                  fi
                  (module avail intelmpi)2>&1 | grep "/opt/intel/mpi/20.*/modulefiles"
                  [[ $? -ne 0 ]] && echo "Check Intel MPI failed" && exit 1
              echo "EFA test passed"
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
